### PR TITLE
Patch cath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-### 0.2.3
+### 0.2.3 (31/08/2023)
 
-* Minor patch; adds missing `overwrite` attribute to `CATHDataModule`. ([#25](https://github.com/a-r-j/ProteinWorkshop/pull/25))
+* Minor patch; adds missing `overwrite` attribute to `CATHDataModule`, `FoldClassificationDataModule` and `GeneOntologyDataModule`. ([#25](https://github.com/a-r-j/ProteinWorkshop/pull/25))
 
 ### 0.2.2 (30/08/2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.3
+
+* Minor patch; adds missing `overwrite` attribute to `CATHDataModule`.
+
 ### 2.0.2 (Unreleased)
 
 * Fixes raw data download triggered by absence of PDB when using pre-processed datasets ([#24](https://github.com/a-r-j/ProteinWorkshop/pull/24))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@ import datetime
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 project = "Protein Workshop"
 author = "Arian R. Jamasb"
-release = "0.2.2"
+release = "0.2.3"
 copyright = f"{datetime.datetime.now().year}, {author}"
 
 # -- General configuration ---------------------------------------------------

--- a/proteinworkshop/datasets/cath.py
+++ b/proteinworkshop/datasets/cath.py
@@ -67,6 +67,7 @@ class CATHDataModule(ProteinDataModule):
             self.transform = None
 
         self.in_memory = in_memory
+        self.overwrite = overwrite
 
         self.batch_size = batch_size
         self.pin_memory = pin_memory

--- a/proteinworkshop/datasets/ec_reaction.py
+++ b/proteinworkshop/datasets/ec_reaction.py
@@ -50,6 +50,7 @@ class EnzymeCommissionReactionDataset(ProteinDataModule):
         self.num_workers = num_workers
         self.shuffle_labels = shuffle_labels
         self.format = format
+        self.overwrite = overwrite
 
         self.prepare_data_per_node = True
         logger.info(

--- a/proteinworkshop/datasets/fold_classification.py
+++ b/proteinworkshop/datasets/fold_classification.py
@@ -55,6 +55,7 @@ class FoldClassificationDataModule(ProteinDataModule):
         self.structure_dir = self.data_dir / "pdbstyle-1.75"
 
         self.in_memory = in_memory
+        self.overwrite = overwrite
 
         self.dataset_fraction = dataset_fraction
         self.batch_size = batch_size

--- a/proteinworkshop/datasets/go.py
+++ b/proteinworkshop/datasets/go.py
@@ -61,6 +61,7 @@ class GeneOntologyDataset(ProteinDataModule):
         self.format = format
 
         self.in_memory = in_memory
+        self.overwrite = overwrite
 
         self.batch_size = batch_size
         self.pin_memory = pin_memory

--- a/proteinworkshop/datasets/masif_site.py
+++ b/proteinworkshop/datasets/masif_site.py
@@ -42,6 +42,7 @@ class MaSIFPPISP(ProteinDataModule):
         else:
             self.transform = None
 
+        self.overwrite = overwrite
         self.in_memory = in_memory
         self.dataset_fraction = dataset_fraction
         self.obsolete = obsolete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "proteinworkshop"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = ["Arian Jamasb <arian@jamasb.io>"]
 readme = "README.md"

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -68,7 +68,7 @@ def test_datasets_have_overwrite_attr(tmp_path):
             if "transform" in cfg.datamodule:
                 cfg.datamodule.transform = None
 
-            if cfg.datamodule._target_ == "graphein.ml.datasets.foldcomp_dataset.FoldCompLightningDataModule":
+            if cfg.datamodule._target_ in {"graphein.ml.datasets.foldcomp_dataset.FoldCompLightningDataModule", "proteinworkshop.datasets.atom3d_datamodule.ATOM3DDataModule"}:
                 continue 
             else:
                 dm = instantiate(cfg.datamodule)

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -46,3 +46,14 @@ def test_instantiate_datasets(tmp_path):
 
         assert dataset, f"Dataset {t} not instantiated!"
         assert isinstance(dataset, LightningDataModule)
+
+
+def test_datasets_have_overwrite_attr():
+        for t in os.listdir(DATASET_CONFIG_DIR):
+            config_path = DATASET_CONFIG_DIR / t
+            cfg = omegaconf.OmegaConf.load(config_path)
+            if cfg.datamodule._target_ = "graphein.ml.datasets.foldcomp_dataset.FoldCompLightningDataModule":
+                continue 
+            else:
+                dm = instantiate(cfg.datamodule)
+                assert hasattr(dm, "overwrite"), f"Datamodules {dm} has no overwrite attribute"

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -52,7 +52,7 @@ def test_datasets_have_overwrite_attr():
         for t in os.listdir(DATASET_CONFIG_DIR):
             config_path = DATASET_CONFIG_DIR / t
             cfg = omegaconf.OmegaConf.load(config_path)
-            if cfg.datamodule._target_ = "graphein.ml.datasets.foldcomp_dataset.FoldCompLightningDataModule":
+            if cfg.datamodule._target_ == "graphein.ml.datasets.foldcomp_dataset.FoldCompLightningDataModule":
                 continue 
             else:
                 dm = instantiate(cfg.datamodule)

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -48,7 +48,7 @@ def test_instantiate_datasets(tmp_path):
         assert isinstance(dataset, LightningDataModule)
 
 
-def test_datasets_have_overwrite_attr():
+def test_datasets_have_overwrite_attr(tmp_path):
         for t in os.listdir(DATASET_CONFIG_DIR):
             config_path = DATASET_CONFIG_DIR / t
             cfg = omegaconf.OmegaConf.load(config_path)

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -52,6 +52,22 @@ def test_datasets_have_overwrite_attr():
         for t in os.listdir(DATASET_CONFIG_DIR):
             config_path = DATASET_CONFIG_DIR / t
             cfg = omegaconf.OmegaConf.load(config_path)
+
+            if "data_dir" in cfg.datamodule:
+            cfg.datamodule.data_dir = tmp_path
+
+            if "path" in cfg.datamodule:
+                cfg.datamodule.path = tmp_path
+
+            if "pdb_dir" in cfg.datamodule:
+                cfg.datamodule.pdb_dir = tmp_path
+
+            if "transforms" in cfg.datamodule:
+                cfg.datamodule.transforms = None
+
+            if "transform" in cfg.datamodule:
+                cfg.datamodule.transform = None
+
             if cfg.datamodule._target_ == "graphein.ml.datasets.foldcomp_dataset.FoldCompLightningDataModule":
                 continue 
             else:

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -54,7 +54,7 @@ def test_datasets_have_overwrite_attr():
             cfg = omegaconf.OmegaConf.load(config_path)
 
             if "data_dir" in cfg.datamodule:
-            cfg.datamodule.data_dir = tmp_path
+                cfg.datamodule.data_dir = tmp_path
 
             if "path" in cfg.datamodule:
                 cfg.datamodule.path = tmp_path


### PR DESCRIPTION
* Adds a missing `overwrite` attribute to the CATHDataModule, FoldClassificationDataModule and GeneOntologyDataModule that wer missed in #23 