### PR TITLE
Standardize `poetry` in README.md, and fix up docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Configuration files to run the experiments described in the manuscript are provi
     - [Edge Construction](#edge-construction)
     - [Invariant Edge Features](#invariant-edge-features)
     - [Equivariant Edge Features](#equivariant-edge-features)
-  - [For developers](#for-developers)
+  - [For Developers](#for-developers)
+    - [Dependency Management](#dependency-management)
+    - [Code Formatting](#code-formatting)
+    - [Documentation](#documentation)
 
 ## Installation
 
@@ -63,11 +66,14 @@ Below, we outline how one may set up a virtual environment for `proteinworkshop`
 
 ### From PyPI
 
-`proteinworkshop` is available for install [from PyPI](https://pypi.org/project/proteinworkshop/). This enables training of specific configurations via the CLI **or** using individual components from the benchmark, such as datasets, featurisers, or transforms, as drop-ins to other projects. Beforehand, make sure to install [PyTorch](https://pytorch.org/) (version `2.0.0`) using its official `pip` installation instructions (with CUDA support as desired).
+`proteinworkshop` is available for install [from PyPI](https://pypi.org/project/proteinworkshop/). This enables training of specific configurations via the CLI **or** using individual components from the benchmark, such as datasets, featurisers, or transforms, as drop-ins to other projects. Make sure to install [PyTorch](https://pytorch.org/) (specifically version `2.0.0`) using its official `pip` installation instructions, with CUDA support as desired.
 
 ```bash
 # install `proteinworkshop` from PyPI
 pip install proteinworkshop --no-cache-dir
+
+# e.g., install PyTorch with CUDA 11.8 support on Linux
+pip install torch==2.0.0+cu118 torchvision==0.15.1+cu118 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu118 --no-cache-dir
 
 # install PyTorch Geometric using the (now-installed) CLI
 workshop install pyg
@@ -79,54 +85,34 @@ export DATA_PATH="where/you/want/data/" # e.g., `export DATA_PATH="proteinworksh
 However, for full exploration we recommend cloning the repository and building from source.
 
 ### Building from source
-
-1. Clone the project
+With a local virtual environment activated (e.g., one created with `conda create -n proteinworkshop python=3.9`):
+1. Clone and install the project
 
     ```bash
     git clone https://github.com/a-r-j/ProteinWorkshop
     cd ProteinWorkshop
+    pip install -e .
     ```
 
-2. Install `poetry` for platform-agnostic dependency management using its [installation instructions](https://python-poetry.org/docs/)
-
-    After installing `poetry`, to avoid potential [keyring errors](https://github.com/python-poetry/poetry/issues/1917#issuecomment-1235998997), disable its keyring usage by adding `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` to your shell's startup configuration and restarting your shell environment (e.g., `echo 'export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring' >> ~/.bashrc && source ~/.bashrc` for a Bash shell environment and likewise for other shell environments).
-
-3. Install project dependencies
+2. Install [PyTorch](https://pytorch.org/) (specifically version `2.0.0`) using its official `pip` installation instructions, with CUDA support as desired (N.B. make sure to add `--no-cache-dir` to the end of the `pip` installation command)
 
     ```bash
-      poetry install
+    # e.g., to install PyTorch with CUDA 11.8 support on Linux:
+    pip install torch==2.0.0+cu118 torchvision==0.15.1+cu118 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu118 --no-cache-dir
     ```
 
-4. Activate the newly-created virtual environment following `poetry`'s [usage documentation](https://python-poetry.org/docs/basic-usage/)
+3. Then use the newly-installed `proteinworkshop` CLI to install [PyTorch Geometric](https://pyg.org/)
 
     ```bash
-      # activate the environment on a `posix`-like (e.g., macOS or Linux) system
-      source $(poetry env info --path)/bin/activate
-    ```
-    ```powershell
-      # activate the environment on a `Windows`-like system
-      & ((poetry env info --path) + "\Scripts\activate.ps1")
-    ```
-    ```bash
-      # if desired, deactivate the environment
-      deactivate
+    workshop install pyg
     ```
 
-5. With the environment activated, install [PyTorch](https://pytorch.org/) (version `2.0.0`) using its official `pip` installation instructions (with CUDA support as desired - N.B. make sure to add `--no-cache-dir` to the end of the `pip` installation command), and then use the (newly-installed) CLI to install [PyTorch Geometric](https://pyg.org/)
+4. Configure paths in `.env` (optional, will override default paths if set). See [`.env.example`](https://github.com/a-r-j/proteinworkshop/blob/main/.env.example) for an example.
+
+5. Download PDB data:
 
     ```bash
-      workshop install pyg
-
-      # N.B. to list all dependencies currently installed, run:
-      poetry show
-    ```
-
-6. Configure paths in `.env` (optional, will override default paths if set). See [`.env.example`](https://github.com/a-r-j/proteinworkshop/blob/main/.env.example) for an example.
-
-7. Download PDB data:
-
-    ```bash
-      python proteinworkshop/scripts/download_pdb_mmtf.py
+    python proteinworkshop/scripts/download_pdb_mmtf.py
     ```
 
 ## Tutorials
@@ -220,7 +206,7 @@ Or an example SLURM submission script:
   #SBATCH --array=0-32
 
   source ~/.bashrc
-  source $(poetry env info --path)/bin/activate
+  source $(conda info --base)/envs/proteinworkshop/bin/activate
 
   wandb agent mywandbgroup/proteinworkshop/2wwtt7oy --count 1
   ```
@@ -309,10 +295,10 @@ Read [the docs](https://www.proteins.sh) for a full list of modules available in
 
 | Name      | Source   | Protein Specific |
 | ----------- | ----------- | ----------- |
-| `GearNet`| [Zhang et al.](https://arxiv.org/pdf/2203.06125) | ✓ |
-| `ProNet`   | [Wang et al.](https://arxiv.org/abs/2207.12600) | ✓ |
-| `DimeNet++`   | [Gasteiger et al.](https://arxiv.org/abs/2011.14115) | ✗ |
-| `SchNet`   | [Schütt et al.](https://arxiv.org/abs/1706.08566) | ✗ |
+| `GearNet`| [Zhang et al.](https://arxiv.org/pdf/2203.06125) | ✓
+| `ProNet`   | [Wang et al.](https://arxiv.org/abs/2207.12600) | ✓
+| `DimeNet++`   | [Gasteiger et al.](https://arxiv.org/abs/2011.14115) | ✗
+| `SchNet`   | [Schütt et al.](https://arxiv.org/abs/1706.08566) | ✗
 
 ### Equivariant Graph Encoders
 
@@ -438,7 +424,7 @@ These are likely to be most frequently used with the [`pdb`](https://github.com/
 
 ## Featurisation Schemes
 
-Part of the goal of `proteinworkshop` benchmark is to investigate the impact of the degree to which increasing granularity of structural detail affects performance. To achieve this, we provide several featurisation schemes for protein structures.
+Part of the goal of the `proteinworkshop` benchmark is to investigate the impact of the degree to which increasing granularity of structural detail affects performance. To achieve this, we provide several featurisation schemes for protein structures.
 
 ### Invariant Node Features
 
@@ -487,11 +473,54 @@ Where the suffix after `knn` or `eps` specifies $k$ (number of neighbours) or $\
 | ----------- | ----------- | ----------- |
 | `edge_vectors` | Edge directional vectors (unit-normalized)        |      1  |
 
-## For developers
-To keep with the code style for the `proteinworkshop` repository, using the following lines please format your commits before opening a pull request:
+## For Developers
+
+### Dependency Management
+We use `poetry` to manage the project's underlying dependencies and to push updates to the project's PyPI package. To make changes to the project's dependencies, follow the instructions below to (**1**) install `poetry` on your local machine; (**2**) customize the dependencies; or (**3**) (de)activate the project's virtual environment using `poetry`:
+1. Install `poetry` for platform-agnostic dependency management using its [installation instructions](https://python-poetry.org/docs/)
+
+    After installing `poetry`, to avoid potential [keyring errors](https://github.com/python-poetry/poetry/issues/1917#issuecomment-1235998997), disable its keyring usage by adding `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` to your shell's startup configuration and restarting your shell environment (e.g., `echo 'export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring' >> ~/.bashrc && source ~/.bashrc` for a Bash shell environment and likewise for other shell environments).
+
+2. Install, add, or upgrade project dependencies
+
+    ```bash
+      poetry install  # install the latest project dependencies
+      # or
+      poetry add XYZ  # add dependency `XYZ` to the project
+      # or
+      poetry show  # list all dependencies currently installed
+      # or
+      poetry lock  # standardize the (now-)installed dependencies
+    ```
+
+3. Activate the newly-created virtual environment following `poetry`'s [usage documentation](https://python-poetry.org/docs/basic-usage/)
+
+    ```bash
+      # activate the environment on a `posix`-like (e.g., macOS or Linux) system
+      source $(poetry env info --path)/bin/activate
+    ```
+    ```powershell
+      # activate the environment on a `Windows`-like system
+      & ((poetry env info --path) + "\Scripts\activate.ps1")
+    ```
+    ```bash
+      # if desired, deactivate the environment
+      deactivate
+    ```
+
+### Code Formatting
+To keep with the code style for the `proteinworkshop` repository, using the following lines, please format your commits before opening a pull request:
 ```bash
 # assuming you are located in the `ProteinWorkshop` top-level directory
 isort . 
 autoflake -r --in-place --remove-unused-variables --remove-all-unused-imports --ignore-init-module-imports . 
 black --config=pyproject.toml .
+```
+
+### Documentation
+To build a local version of the project's Sphinx documentation web pages:
+```bash
+# assuming you are located in the `ProteinWorkshop` top-level directory
+pip install -r docs/.docs.requirements # one-time only
+rm -rf docs/build/ && sphinx-build docs/source/ docs/build/ # NOTE: errors can safely be ignored
 ```

--- a/docs/source/configs/dataset.rst
+++ b/docs/source/configs/dataset.rst
@@ -31,8 +31,8 @@ Unlabelled Datasets
 
 
 .. mdinclude:: ../../../README.md
-    :start-line: 345
-    :end-line: 387
+    :start-line: 331
+    :end-line: 373
 
 
 :py:class:`ASTRAL <proteinworkshop.datasets.astral.AstralDataModule>` (``astral``)

--- a/docs/source/configs/features.rst
+++ b/docs/source/configs/features.rst
@@ -7,8 +7,8 @@ Features
   :width: 400
 
 .. mdinclude:: ../../../README.md
-    :start-line: 440
-    :end-line: 489
+    :start-line: 426
+    :end-line: 475
 
 
 Default Features

--- a/docs/source/configs/framework_components/env.rst
+++ b/docs/source/configs/framework_components/env.rst
@@ -2,8 +2,8 @@ Environment
 ------------
 
 .. mdinclude:: ../../../../README.md
-    :start-line: 123
-    :end-line: 125
+    :start-line: 109
+    :end-line: 111
 
 .. literalinclude:: ../../../../.env.example
     :language: bash

--- a/docs/source/configs/model.rst
+++ b/docs/source/configs/model.rst
@@ -34,8 +34,8 @@ Invariant Encoders
 =============================
 
 .. mdinclude:: ../../../README.md
-    :start-line: 309
-    :end-line: 316
+    :start-line: 295
+    :end-line: 302
 
 :py:class:`SchNet <proteinworkshop.models.graph_encoders.schnet.SchNetModel>` (``schnet``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,8 +117,8 @@ Vector-Equivariant Encoders
 =============================
 
 .. mdinclude:: ../../../README.md
-    :start-line: 320
-    :end-line: 326
+    :start-line: 306
+    :end-line: 312
 
 :py:class:`EGNN <proteinworkshop.models.graph_encoders.egnn.EGNNModel>` (``egnn``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -170,8 +170,8 @@ Tensor-Equivariant Encoders
 =============================
 
 .. mdinclude:: ../../../README.md
-    :start-line: 328
-    :end-line: 333
+    :start-line: 314
+    :end-line: 319
 
 
 :py:class:`Tensor Field Networks <proteinworkshop.models.graph_encoders.tfn.TensorProductModel>` (``tfn``)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,13 @@ Welcome to Protein Workshop's documentation!
 
 .. mdinclude:: ../../README.md
     :start-line: 1
-    :end-line: 12
+    :end-line: 10
+
+.. image:: ../_static/workshop_overview.png
+  :alt: Overview of the Protein Workshop
+  :align: center
+  :width: 400
+
 .. mdinclude:: ../../README.md
     :start-line: 14
     :end-line: 22

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,5 +5,5 @@ Installation
     :doc:`/configs/framework_components/env`
 
 .. mdinclude:: ../../README.md
-    :start-line: 61
-    :end-line: 123
+    :start-line: 64
+    :end-line: 109

--- a/docs/source/modules/proteinworkshop.models.rst
+++ b/docs/source/modules/proteinworkshop.models.rst
@@ -98,7 +98,7 @@ Tensor-Equivariant Encoders
 
 TFN (``tfn``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automodule:: proteinworkshop.models.graph_encoders.gcpnet
+.. automodule:: proteinworkshop.models.graph_encoders.tfn
     :members:
     :undoc-members:
     :show-inheritance:
@@ -106,7 +106,7 @@ TFN (``tfn``)
 
 Multi-Atomic Cluster Expansion (``mace``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. automodule:: proteinworkshop.models.graph_encoders.gcpnet
+.. automodule:: proteinworkshop.models.graph_encoders.mace
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -2,8 +2,8 @@ Quickstart
 ---------------------
 
 .. mdinclude:: ../../README.md
-    :start-line: 144
-    :end-line: 305
+    :start-line: 130
+    :end-line: 289
 
 .. toctree::
     :maxdepth: 3

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -2,8 +2,8 @@ Tutorials
 ---------------------
 
 .. mdinclude:: ../../README.md
-    :start-line: 133
-    :end-line: 142
+    :start-line: 119
+    :end-line: 128
 
 
 Training a New Model

--- a/proteinworkshop/models/decoders/mlp_decoder.py
+++ b/proteinworkshop/models/decoders/mlp_decoder.py
@@ -63,7 +63,7 @@ class LinearSkipBlock(nn.Module):
         self.activations.append(get_activations(self.activation_fns[-1]))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore
-        """Implement forward pass of MLP with skip connections.
+        """Implements the forward pass of the MLP decoder with skip connections.
 
         :param x: Input tensor
         :type x: torch.Tensor

--- a/proteinworkshop/models/graph_encoders/dimenetpp.py
+++ b/proteinworkshop/models/graph_encoders/dimenetpp.py
@@ -120,13 +120,18 @@ class DimeNetPPModel(DimeNetPlusPlus):
         return {"pos", "edge_index", "x", "batch"}
 
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """Implementation of the forward pass of the DimeNet++ model.
+        """Implements the forward pass of the DimeNet++ encoder.
+        
+        Returns the node embedding and graph embedding in a dictionary.
 
         :param batch: Batch of data to encode.
         :type batch: Union[Batch, ProteinBatch]
-        :return: Dictionary with ``node_embedding`` and ``graph_embedding``
-            fields: node representations of shape :math:`(|V|, d)`, graph
-            representations of shape :math:`(n, d)`
+        :return: Dictionary of node and graph embeddings. Contains
+            ``node_embedding`` and ``graph_embedding`` fields. The node
+            embedding is of shape :math:`(|V|, d)` and the graph embedding is
+            of shape :math:`(n, d)`, where :math:`|V|` is the number of nodes
+            and :math:`n` is the number of graphs in the batch and :math:`d` is
+            the dimension of the embeddings.
         :rtype: EncoderOutput
         """
         i, j, idx_i, idx_j, idx_k, idx_kj, idx_ji = triplets(

--- a/proteinworkshop/models/graph_encoders/egnn.py
+++ b/proteinworkshop/models/graph_encoders/egnn.py
@@ -72,17 +72,18 @@ class EGNNModel(nn.Module):
         return {"x", "pos", "edge_index", "batch"}
 
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """Performs a forward pass of the EGNN model.
+        """Implements the forward pass of the EGNN encoder.
+        
+        Returns the node embedding and graph embedding in a dictionary.
 
-        Returns the node embedding and graph embedding in a dictionary with
-        fields ``node_embedding`` and ``graph_embedding``. The node embedding
-        is of shape :math:`(n, d)` and the graph embedding is of shape
-        :math:`(batch_size, d)`, where :math:`n` is the number of nodes and
-        :math:`d` is the dimension of the embeddings.
-
-        :param batch: Batch of data to encode
+        :param batch: Batch of data to encode.
         :type batch: Union[Batch, ProteinBatch]
-        :return: Dictionary of node and graph embeddings
+        :return: Dictionary of node and graph embeddings. Contains
+            ``node_embedding`` and ``graph_embedding`` fields. The node
+            embedding is of shape :math:`(|V|, d)` and the graph embedding is
+            of shape :math:`(n, d)`, where :math:`|V|` is the number of nodes
+            and :math:`n` is the number of graphs in the batch and :math:`d` is
+            the dimension of the embeddings.
         :rtype: EncoderOutput
         """
         h = self.emb_in(batch.x)  # (n,) -> (n, d)

--- a/proteinworkshop/models/graph_encoders/gcpnet.py
+++ b/proteinworkshop/models/graph_encoders/gcpnet.py
@@ -159,6 +159,20 @@ class GCPNetModel(torch.nn.Module):
     @jaxtyped
     @beartype
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
+        """Implements the forward pass of the GCPNet encoder.
+        
+        Returns the node embedding and graph embedding in a dictionary.
+
+        :param batch: Batch of data to encode.
+        :type batch: Union[Batch, ProteinBatch]
+        :return: Dictionary of node and graph embeddings. Contains
+            ``node_embedding`` and ``graph_embedding`` fields. The node
+            embedding is of shape :math:`(|V|, d)` and the graph embedding is
+            of shape :math:`(n, d)`, where :math:`|V|` is the number of nodes
+            and :math:`n` is the number of graphs in the batch and :math:`d` is
+            the dimension of the embeddings.
+        :rtype: EncoderOutput
+        """
         # Centralize node positions to make them translation-invariant
         pos_centroid, batch.pos = self.centralize(
             batch, batch_index=batch.batch

--- a/proteinworkshop/models/graph_encoders/gear_net.py
+++ b/proteinworkshop/models/graph_encoders/gear_net.py
@@ -133,14 +133,18 @@ class GearNet(nn.Module):
         }
 
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """
-        Compute the node representations and the graph representation(s).
+        """Implements the forward pass of the GearNet encoder.
+
+        Returns the node embedding and graph embedding in a dictionary.
 
         :param batch: Batch of data to encode.
         :type batch: Union[Batch, ProteinBatch]
-
-        :return: Dictionary  with ``node_feature`` and ``graph_feature`` fields:
-        node representations of shape :math:`(|V|, d)`, graph representations of shape :math:`(n, d)`
+        :return: Dictionary of node and graph embeddings. Contains
+            ``node_embedding`` and ``graph_embedding`` fields. The node
+            embedding is of shape :math:`(|V|, d)` and the graph embedding is
+            of shape :math:`(n, d)`, where :math:`|V|` is the number of nodes
+            and :math:`n` is the number of graphs in the batch and :math:`d` is
+            the dimension of the embeddings.
         :rtype: EncoderOutput
         """
         hiddens = []

--- a/proteinworkshop/models/graph_encoders/gnn.py
+++ b/proteinworkshop/models/graph_encoders/gnn.py
@@ -169,7 +169,20 @@ class GNNModel(nn.Module):
     @jaxtyped
     @beartype
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """Implements the forward pass of the GNN encoder."""
+        """Implements the forward pass of the GNN encoder.
+        
+        Returns the node embedding and graph embedding in a dictionary.
+
+        :param batch: Batch of data to encode.
+        :type batch: Union[Batch, ProteinBatch]
+        :return: Dictionary of node and graph embeddings. Contains
+            ``node_embedding`` and ``graph_embedding`` fields. The node
+            embedding is of shape :math:`(|V|, d)` and the graph embedding is
+            of shape :math:`(n, d)`, where :math:`|V|` is the number of nodes
+            and :math:`n` is the number of graphs in the batch and :math:`d` is
+            the dimension of the embeddings.
+        :rtype: EncoderOutput
+        """
         if self.edge_weight:
             x, edge_index, edge_weight = (
                 batch.x,

--- a/proteinworkshop/models/graph_encoders/gvp.py
+++ b/proteinworkshop/models/graph_encoders/gvp.py
@@ -132,7 +132,9 @@ class GVPGNNModel(torch.nn.Module):
     @jaxtyped
     @beartype
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """Returns the node embedding and graph embedding in a dictionary.
+        """Implements the forward pass of the GVP-GNN encoder.
+
+        Returns the node embedding and graph embedding in a dictionary.
 
         :param batch: Batch of data to encode.
         :type batch: Union[Batch, ProteinBatch]

--- a/proteinworkshop/models/graph_encoders/identity.py
+++ b/proteinworkshop/models/graph_encoders/identity.py
@@ -36,13 +36,18 @@ class IdentityModel(nn.Module):
     @jaxtyped
     @beartype
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """Implements the forward pass of the IdentityModel class.
+        """Implements the forward pass of the IdentityModel encoder.
 
         Returns the node embedding and graph embedding in a dictionary.
 
         :param batch: Batch of data to encode.
         :type batch: Union[Batch, ProteinBatch]
-        :return: Dictionary of node and graph embeddings.
+        :return: Dictionary of node and graph embeddings. Contains
+            ``node_embedding`` and ``graph_embedding`` fields. The node
+            embedding is of shape :math:`(|V|, d)` and the graph embedding is
+            of shape :math:`(n, d)`, where :math:`|V|` is the number of nodes
+            and :math:`n` is the number of graphs in the batch and :math:`d` is
+            the dimension of the embeddings.
         :rtype: EncoderOutput
         """
         output = {

--- a/proteinworkshop/models/graph_encoders/mace.py
+++ b/proteinworkshop/models/graph_encoders/mace.py
@@ -209,7 +209,9 @@ class MACEModel(torch.nn.Module):
     @jaxtyped
     @beartype
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """Returns the node embedding and graph embedding in a dictionary.
+        """Implements the forward pass of the MACE encoder.
+
+        Returns the node embedding and graph embedding in a dictionary.
 
         :param batch: Batch of data to encode.
         :type batch: Union[Batch, ProteinBatch]

--- a/proteinworkshop/models/graph_encoders/schnet.py
+++ b/proteinworkshop/models/graph_encoders/schnet.py
@@ -86,13 +86,18 @@ class SchNetModel(SchNet):
         return {"pos", "edge_index", "x", "batch"}
 
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """Implementation of the forward pass of the SchNet model.
+        """Implements the forward pass of the SchNet encoder.
+
+        Returns the node embedding and graph embedding in a dictionary.
 
         :param batch: Batch of data to encode.
         :type batch: Union[Batch, ProteinBatch]
-        :return: Dictionary with ``node_embedding`` and ``graph_embedding``
-            fields: node representations of shape :math:`(|V|, d)`, graph
-            representations of shape :math:`(n, d)`
+        :return: Dictionary of node and graph embeddings. Contains
+            ``node_embedding`` and ``graph_embedding`` fields. The node
+            embedding is of shape :math:`(|V|, d)` and the graph embedding is
+            of shape :math:`(n, d)`, where :math:`|V|` is the number of nodes
+            and :math:`n` is the number of graphs in the batch and :math:`d` is
+            the dimension of the embeddings.
         :rtype: EncoderOutput
         """
         h = self.embedding(batch.x)

--- a/proteinworkshop/models/graph_encoders/tfn.py
+++ b/proteinworkshop/models/graph_encoders/tfn.py
@@ -169,7 +169,9 @@ class TensorProductModel(torch.nn.Module):
     @jaxtyped
     @beartype
     def forward(self, batch: Union[Batch, ProteinBatch]) -> EncoderOutput:
-        """Returns the node embedding and graph embedding in a dictionary.
+        """Implements the forward pass of the TFN encoder.
+
+        Returns the node embedding and graph embedding in a dictionary.
 
         :param batch: Batch of data to encode.
         :type batch: Union[Batch, ProteinBatch]


### PR DESCRIPTION
* Moves `poetry` details to the `For developers` section in the README.
* All `docs` pages have been updated to match up with the line numbers in `README.md`.
* Also fixed up some docstrings for different encoders.
* The `docs` will need to be redeployed after merging this in.
* This should address the issue: https://github.com/a-r-j/ProteinWorkshop/issues/29.