### PR TITLE
Add configs and optional post embedding MLP for ESM encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
+### 0.2.5 (25/09/2024)
+
+* Implement ESM embedding encoder ([#33](https://github.com/a-r-j/ProteinWorkshop/pull/33), [#41](https://github.com/a-r-j/ProteinWorkshop/pull/33))
+
 ### 0.2.4 (10/09/2024)
 
 * Fixes error in Metal3D processed download link ([#28](https://github.com/a-r-j/ProteinWorkshop/pull/28))
 * Fixes typo in wandb run name setting ([#30](https://github.com/a-r-j/ProteinWorkshop/pull/30))
 * Fixes paths for models and datasets when testing instantiation of each module ([#32](https://github.com/a-r-j/ProteinWorkshop/pull/32))
 * Improvements to TFN, MACE and EGNN models and layers, including DiffDock-style intermediate edge feature creation (TFN), dropout, gaussian RBF, mean global pooling ([#38](https://github.com/a-r-j/ProteinWorkshop/pull/38))
-* Implement ESM embedding encoder ([#33](https://github.com/a-r-j/ProteinWorkshop/pull/33), [#41](https://github.com/a-r-j/ProteinWorkshop/pull/33))
 
 ### 0.2.3 (31/08/2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixes typo in wandb run name setting ([#30](https://github.com/a-r-j/ProteinWorkshop/pull/30))
 * Fixes paths for models and datasets when testing instantiation of each module ([#32](https://github.com/a-r-j/ProteinWorkshop/pull/32))
 * Improvements to TFN, MACE and EGNN models and layers, including DiffDock-style intermediate edge feature creation (TFN), dropout, gaussian RBF, mean global pooling ([#38](https://github.com/a-r-j/ProteinWorkshop/pull/38))
+* Implement ESM embedding encoder ([#33](https://github.com/a-r-j/ProteinWorkshop/pull/33), [#41](https://github.com/a-r-j/ProteinWorkshop/pull/33))
 
 ### 0.2.3 (31/08/2023)
 

--- a/proteinworkshop/config/encoder/esm.yaml
+++ b/proteinworkshop/config/encoder/esm.yaml
@@ -4,3 +4,4 @@ model: "ESM-2-650M"
 readout: "mean"
 mlp_post_embed: False
 dropout: 0.1
+finetune: False

--- a/proteinworkshop/config/encoder/esm.yaml
+++ b/proteinworkshop/config/encoder/esm.yaml
@@ -2,3 +2,5 @@ _target_: "proteinworkshop.models.graph_encoders.esm_embeddings.EvolutionaryScal
 path: ${env.paths.root_dir}/esm/
 model: "ESM-2-650M"
 readout: "mean"
+mlp_post_embed: False
+dropout: 0.1

--- a/proteinworkshop/config/encoder/esm.yaml
+++ b/proteinworkshop/config/encoder/esm.yaml
@@ -1,0 +1,4 @@
+_target_: "proteinworkshop.models.graph_encoders.esm_embeddings.EvolutionaryScaleModeling"
+path: ${env.paths.root_dir}/esm/
+model: "ESM-2-650M"
+readout: "mean"

--- a/proteinworkshop/config/sweeps/baseline_fold_esm.yaml
+++ b/proteinworkshop/config/sweeps/baseline_fold_esm.yaml
@@ -1,0 +1,68 @@
+program: proteinworkshop/train.py
+method: grid
+name: baseline_hyperparameter_search_esm
+metric:
+  goal: minimize
+  name: val/loss/total
+
+parameters:
+  dataset:
+    values: [fold_family, fold_superfamily, fold_fold]
+  
+  dataset.datamodule.batch_size:
+    value: 4
+  
+  decoder.graph_label.dropout:
+    values:
+      - 0
+      - 0.1
+      - 0.3
+      - 0.5
+  
+  encoder:
+    value: esm
+  
+  encoder.mlp_post_embed:
+    values:
+      - False
+      - True
+  
+  extras.enforce_tags:
+    value: false
+  
+  features:
+    value: ca_bb
+  
+  logger:
+    value: wandb
+  
+  name:
+    value: ${hydra:runtime.choices.encoder}_${hydra:runtime.choices.features}_lr_${optimiser.optimizer.lr}_d_${decoder.graph_label.dropout}
+  
+  optimiser.optimizer.lr:
+    values:
+      - 1e-05
+      - 0.0001
+      - 0.0003
+      - 0.001
+  
+  scheduler:
+    value: plateau
+  
+  task:
+    values:
+      - multiclass_graph_classification
+  
+  test:
+    value: true
+  
+  trainer.max_epochs:
+    value: 20
+
+command:
+  - ${env}
+  - HYDRA_FULL_ERROR=1
+  - WANDB_START_METHOD=thread
+  - python
+  - ${program}
+  - ${args_no_hyphens}

--- a/proteinworkshop/config/sweeps/baseline_fold_esm.yaml
+++ b/proteinworkshop/config/sweeps/baseline_fold_esm.yaml
@@ -9,9 +9,6 @@ parameters:
   dataset:
     values: [fold_family, fold_superfamily, fold_fold]
   
-  dataset.datamodule.batch_size:
-    value: 4
-  
   decoder.graph_label.dropout:
     values:
       - 0
@@ -24,8 +21,8 @@ parameters:
   
   encoder.mlp_post_embed:
     values:
-      - False
-      - True
+      - false
+      - true
   
   extras.enforce_tags:
     value: false
@@ -37,7 +34,7 @@ parameters:
     value: wandb
   
   name:
-    value: ${hydra:runtime.choices.encoder}_${hydra:runtime.choices.features}_lr_${optimiser.optimizer.lr}_d_${decoder.graph_label.dropout}
+    value: ${hydra:runtime.choices.encoder}_${hydra:runtime.choices.features}_post-mlp_${encoder.mlp_post_embed}_lr_${optimiser.optimizer.lr}_d_${decoder.graph_label.dropout}
   
   optimiser.optimizer.lr:
     values:
@@ -57,7 +54,7 @@ parameters:
     value: true
   
   trainer.max_epochs:
-    value: 20
+    value: 150
 
 command:
   - ${env}

--- a/proteinworkshop/models/graph_encoders/esm_embeddings.py
+++ b/proteinworkshop/models/graph_encoders/esm_embeddings.py
@@ -125,7 +125,7 @@ class EvolutionaryScaleModeling(nn.Module):
 
     max_input_length = 1024 - 2
 
-    def __init__(self, path: Union[str, os.PathLike], model: str = "ESM-1b", readout: str = "mean"):
+    def __init__(self, path: Union[str, os.PathLike], model: str = "ESM-2-650M", readout: str = "mean"):
         super(EvolutionaryScaleModeling, self).__init__()
         path = os.path.expanduser(path)
         if not os.path.exists(path):


### PR DESCRIPTION
This PR implements:
- ESM encoder configs
- Optional post embedding MLP after getting ESM embeddings -- this allows the model to merge structural featurisation with ESM features and could be a stronger baseline.
- Optionally allow freezing or finetuning ESM