### PR TITLE
Fix data_dir creation error in download_processed_data.py

### DIFF
--- a/proteinworkshop/scripts/download_processed_data.py
+++ b/proteinworkshop/scripts/download_processed_data.py
@@ -91,7 +91,7 @@ def download_processed_data(dataset_name: str, data_dir: Optional[str] = None):
 
     if not os.path.exists(data_dir):
         logger.info(f"Creating data directory at {data_dir}")
-        os.makedirs(parents=True, exist_ok=True)
+        data_dir.mkdir(parents=True, exist_ok=True)
 
     fname = dataset_fname_map[dataset_name]
     save_file = data_dir / f"{fname}.tar.gz"


### PR DESCRIPTION
This pull request addresses an issue encountered when using the workshop download command with the argument cath. The specific error reported was:

```bash
Traceback (most recent call last):
  File "/opt/python3/venv/base/bin/workshop", line 8, in <module>
    sys.exit(main())
  File "/opt/python3/venv/base/lib/python3.10/site-packages/proteinworkshop/scripts/cli.py", line 133, in main
    download_processed_data(args.dataset)
  File "/opt/python3/venv/base/lib/python3.10/site-packages/proteinworkshop/scripts/download_processed_data.py", line 94, in download_processed_data
    os.makedirs(parents=True, exist_ok=True)
TypeError: makedirs() got an unexpected keyword argument 'parents'
```

**Solution:**
The PR fixes this issue by updating the implementation of the directory creation.

**Testing:**
The fix has been tested locally to ensure that the workshop download cath command now executes successfully without raising a TypeError.