### PR TITLE
refactor multi test set datasets; add seq id test splits to GO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.2.6 (UNRELEASED)
+
+* Add stage-based conditions to `setup` in `ProteinDataModule` [#72](https://github.com/a-r-j/ProteinWorkshop/pull/72)
+* Improves support for datamodules with multiple test sets. Generalises this to support GO and FOLD. Also adds multiple seq ID.-based splits for GO. [#72](https://github.com/a-r-j/ProteinWorkshop/pull/72)
+
+
 ### 0.2.5 (28/12/2023)
 
 #### Datasets

--- a/README.md
+++ b/README.md
@@ -557,3 +557,18 @@ To build a local version of the project's Sphinx documentation web pages:
 pip install -r docs/.docs.requirements # one-time only
 rm -rf docs/build/ && sphinx-build docs/source/ docs/build/ # NOTE: errors can safely be ignored
 ```
+
+## Citing `ProteinWorkshop`
+
+Please consider citing `proteinworkshop` if it proves useful in your work.
+
+```bibtex
+@inproceedings{
+  jamasb2024evaluating,
+  title={Evaluating Representation Learning on the Protein Structure Universe},
+  author={Arian R. Jamasb, Alex Morehead, Zuobai Zhang, Chaitanya K. Joshi,Kieran Didi, Simon V. Mathis, Charles Harris, Jian Tang, Jianlin Cheng,Pietro Lio, Tom L. Blundell},
+  booktitle={The Twelfth International Conference on Learning Representations},
+  year={2024},
+}
+
+```

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ Please consider citing `proteinworkshop` if it proves useful in your work.
 @inproceedings{
   jamasb2024evaluating,
   title={Evaluating Representation Learning on the Protein Structure Universe},
-  author={Arian R. Jamasb, Alex Morehead, Zuobai Zhang, Chaitanya K. Joshi,Kieran Didi, Simon V. Mathis, Charles Harris, Jian Tang, Jianlin Cheng,Pietro Lio, Tom L. Blundell},
+  author={Arian R. Jamasb, Alex Morehead, Zuobai Zhang, Chaitanya K. Joshi, Kieran Didi, Simon V. Mathis, Charles Harris, Jian Tang, Jianlin Cheng, Pietro Lio, Tom L. Blundell},
   booktitle={The Twelfth International Conference on Learning Representations},
   year={2024},
 }

--- a/citation.bib
+++ b/citation.bib
@@ -1,0 +1,7 @@
+@inproceedings{
+jamasb2024evaluating,
+title={Evaluating Representation Learning on the Protein Structure Universe},
+author={Arian R. Jamasb, Alex Morehead, Zuobai Zhang, Chaitanya K. Joshi, Kieran Didi, Simon V. Mathis, Charles Harris, Jian Tang, Jianlin Cheng, Pietro Lio, Tom L. Blundell},
+booktitle={The Twelfth International Conference on Learning Representations},
+year={2024},
+}

--- a/proteinworkshop/datasets/fold_classification.py
+++ b/proteinworkshop/datasets/fold_classification.py
@@ -218,17 +218,6 @@ class FoldClassificationDataModule(ProteinDataModule):
             num_workers=self.num_workers,
         )
 
-    # def get_test_loader(self, split: str) -> ProteinDataLoader:
-    #    log.info(f"Getting test loader: {split}")
-    #    test_ds = self._get_dataset(f"test_{split}")
-    #    return ProteinDataLoader(
-    #        test_ds,
-    #        batch_size=self.batch_size,
-    #        shuffle=False,
-    #        pin_memory=self.pin_memory,
-    #        num_workers=self.num_workers,
-    #    )
-
     def parse_dataset(self, split: str) -> pd.DataFrame:
         """
         Parses the raw dataset files to Pandas DataFrames.

--- a/proteinworkshop/datasets/go.py
+++ b/proteinworkshop/datasets/go.py
@@ -142,20 +142,6 @@ class GeneOntologyDataset(ProteinDataModule):
         log.info(f"Encoded {len(labels)} labels for task {self.split}.")
         return labels
 
-    # def get_test_loader(
-    #    self,
-    #    split: Literal["test_0.3", "test_0.4", "test_0.5", "test_0.7", "test_0.95"],
-    # ) -> ProteinDataLoader:
-    #    log.info(f"Getting test loader: {split}")
-    #    test_ds = self._get_dataset(split)
-    #    return ProteinDataLoader(
-    #        test_ds,
-    #        batch_size=self.batch_size,
-    #        shuffle=False,
-    #        pin_memory=self.pin_memory,
-    #        num_workers=self.num_workers,
-    #    )
-
     def _get_dataset(
         self,
         split: Literal[


### PR DESCRIPTION
* Improves API for multi test set datasets
* Improves `setup` in base datamodule to avoid setting up all datasets at once
* Adds caching to avoid duplicating in memory loading
* Adds seq id splits to GO dataset. 