### PR TITLE
Fix PDB download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Models
 
 * Adds missing `pos` attribute to GearNet `required_batch_attributes` (fixes [#73](https://github.com/a-r-j/ProteinWorkshop/issues/73)) [#74](https://github.com/a-r-j/ProteinWorkshop/pull/74)
+* Fixes PDB download failure due to missing protein data [#77](https://github.com/a-r-j/ProteinWorkshop/pull/77)
 
 ### Framework
 

--- a/proteinworkshop/datasets/utils.py
+++ b/proteinworkshop/datasets/utils.py
@@ -7,6 +7,8 @@ import os
 import os.path
 import pathlib
 import tarfile
+import logging
+import time
 from typing import List, Optional
 
 import biotite.database.rcsb as rcsb
@@ -38,6 +40,8 @@ def flatten_dir(dir: os.PathLike):
                 print(f"Could not move {os.path.join(dirpath, filename)}")
 
 
+
+
 def download_pdb_mmtf(
     mmtf_dir: pathlib.Path,
     ids: Optional[List[str]] = None,
@@ -67,10 +71,26 @@ def download_pdb_mmtf(
         all_id_query = rcsb.FieldQuery("struct.title")
         pdb_ids = rcsb.search(all_id_query)
         pdb_ids = [pdb_id.lower() for pdb_id in pdb_ids]
+    else:
+        pdb_ids = ids
 
     # Name for download directory
     if not os.path.isdir(mmtf_dir):
         os.mkdir(mmtf_dir)
+
+    def catched_rcsb_fetch(pdb_id, max_retries=5, retry_interval=100):
+        data = None
+        for retry_idx in range(max_retries):
+            try:
+                data = rcsb.fetch(pdb_id, format="mmtf", target_path=mmtf_dir)
+                break
+            except Exception as e:
+                logging.warn(f"Attempt {retry_idx} to fetch pdb_id {pdb_id} failed: {e}")
+            time.sleep(retry_interval/1000)
+            
+        if data is None:
+            logging.warn(f"Failed to fetch pdb_id {pdb_id}")
+        return data
 
     # Download all PDB IDs with parallelized HTTP requests
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
@@ -82,7 +102,7 @@ def download_pdb_mmtf(
                 f"Submitting PDB download request for {pdb_id}"
             )
             futures.append(
-                executor.submit(rcsb.fetch, pdb_id, "mmtf", mmtf_dir)
+                executor.submit(catched_rcsb_fetch, pdb_id)
             )
         pbar = tqdm(concurrent.futures.as_completed(futures))
         for request_index, future in enumerate(pbar):

--- a/proteinworkshop/scripts/download_pdb_mmtf.py
+++ b/proteinworkshop/scripts/download_pdb_mmtf.py
@@ -1,77 +1,13 @@
 # Code source: Patrick Kunzmann
 # License: BSD 3 clause
 
-import concurrent.futures
-import os
-import os.path
-import pathlib
-import tarfile
-
-import biotite.database.rcsb as rcsb
-from tqdm import tqdm
+from pathlib import Path
 
 from proteinworkshop.constants import DATA_PATH
-
+from proteinworkshop.datasets.utils import download_pdb_mmtf as _download_pdb_mmtf
 
 def download_pdb_mmtf(create_tar: bool = True):
-    ### Download of PDB and archive creation ###
-
-    # MMTF files are downloaded into a new directory in this path
-    # and the .tar archive is created here
-    mmtf_dir = pathlib.Path(DATA_PATH) / "pdb"
-
-    # Obtain all PDB IDs using a query that includes all entries
-    # Each PDB entry has a title
-    all_id_query = rcsb.FieldQuery("struct.title")
-    pdb_ids = rcsb.search(all_id_query)
-    pdb_ids = [pdb_id.lower() for pdb_id in pdb_ids]
-
-    # Name for download directory
-    if not os.path.isdir(mmtf_dir):
-        os.mkdir(mmtf_dir)
-
-    # Download all PDB IDs with parallelized HTTP requests
-    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-        futures = []
-        num_requests = len(pdb_ids)
-        pbar = tqdm(pdb_ids)
-        for pdb_id in pbar:
-            pbar.set_description(
-                f"Submitting PDB download request for {pdb_id}"
-            )
-            futures.append(
-                executor.submit(rcsb.fetch, pdb_id, "mmtf", mmtf_dir)
-            )
-        pbar = tqdm(concurrent.futures.as_completed(futures))
-        for request_index, future in enumerate(pbar):
-            pbar.set_description(
-                f"Waiting for PDB download request #{request_index + 1}/{num_requests} to complete"
-            )
-            # Wait for the future to complete
-            future.result()
-
-    if create_tar:
-        # Create .tar archive file from MMTF files in directory
-        with tarfile.open(f"{mmtf_dir}.tar", mode="w") as file:
-            pbar = tqdm(pdb_ids)
-            for pdb_id in pbar:
-                pbar.set_description(
-                    f"Adding downloaded PDB {pdb_id} to {f'{mmtf_dir}.tar'}"
-                )
-                file.add(
-                    os.path.join(mmtf_dir, f"{pdb_id}.mmtf"), f"{pdb_id}.mmtf"
-                )
-
-    ### File access for analysis ###
-
-    # Iterate over all files in archive;
-    # Instead of extracting the files from the archive,
-    # the `.tar` file is directly accessed
-    # with tarfile.open(f"{mmtf_dir}.tar", mode="r") as file:
-    # for member in file.getnames():
-    # mmtf_file = mmtf.MMTFFile.read(file.extractfile(member))
-    ## Do some fancy stuff with the data...
-
+    _download_pdb_mmtf(Path(DATA_PATH) / "pdb", create_tar=create_tar)
 
 if __name__ == "__main__":
     download_pdb_mmtf()


### PR DESCRIPTION
### Issue:
* `workshop download pdb` gets stuck, failing to terminate.

### Cause:
* The pretein [pdb_id: 8CKB](https://www.rcsb.org/structure/8CKB) is not available in the mmtf format, as verified with the official `mmtf-python` API. This causes `rcsb.fetch` to throw `RequestError` which, when uncaught, causes the entire download process to hang.

### Solution:
* Catch `RequestError` in `download_pdb_mmtf`
* Attempt retries in case of network issues

During implementation, I found that `download_pdb_mmtf` is duplicated in `datasets/utils` and `scripts/download_pdb_mmtf`.
* Remove code duplication