### PR TITLE
Add forced cuda version to `workshop install`

### DIFF
--- a/proteinworkshop/scripts/cli.py
+++ b/proteinworkshop/scripts/cli.py
@@ -24,6 +24,15 @@ def main():
         default=False,
         required=False,
     )
+
+    install_parser.add_argument(
+        "--force-cuda-version",
+        type=int,
+        help="set cuda version manually, ignore automatic detection. e.g. 121 for CUDA 12.1",
+        default=None,
+        required=False,
+    )
+
     install_parser.add_argument(
         "dependency", choices=["pyg"], help="dependency help"
     )
@@ -112,7 +121,7 @@ def main():
         # lazy import
         from .install_pyg import _install_pyg
 
-        _install_pyg(args.force_reinstall)
+        _install_pyg(args.force_reinstall, args.force_cuda_version)
 
     elif args.command == "download":
         if args.dataset == "pdb":

--- a/proteinworkshop/scripts/install_pyg.py
+++ b/proteinworkshop/scripts/install_pyg.py
@@ -4,7 +4,8 @@ import torch
 from loguru import logger
 
 
-def _install_pyg(force_reinstall: bool = False):
+def _install_pyg(force_reinstall: bool = False,
+                 force_cuda_version: int = None):
     torch_version = torch.__version__
     cuda_version = (
         torch.version.cuda.replace(".", "")
@@ -13,6 +14,10 @@ def _install_pyg(force_reinstall: bool = False):
     )
     logger.info(f"Detected PyTorch version: {torch_version}")
     logger.info(f"Detected CUDA version: {cuda_version}")
+    if force_cuda_version is not None:
+        logger.info(f"Forcing CUDA version to {force_cuda_version}")
+        cuda_version = force_cuda_version
+    
     logger.info(
         f"Installing PyTorch Geometric for PyTorch {torch_version} and CUDA {cuda_version}"
     )


### PR DESCRIPTION
### Background
It is sometime necessary to install PyG with CUDA, when if the current machine does not have CUDA support. For example, when setting up a development environment on a disk shared between a server and a GPU cluster.

### Solution
Add optional argument `--force-cuda-version` for `workshop install`, overrides automatically detected CUDA version.