### PR TITLE
Fix `sequence_edges` when b is a Data object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### Command
 * Adds `--force-cuda-version` to `workshop install` [#78](https://github.com/a-r-j/ProteinWorkshop/pull/78)
 
+### Features
+* Fix `sequence_edges` behaviour when argument `b` is a `Data` object [#80](https://github.com/a-r-j/ProteinWorkshop/pull/80)
 
 ### 0.2.5 (28/12/2023)
 

--- a/proteinworkshop/features/edges.py
+++ b/proteinworkshop/features/edges.py
@@ -104,7 +104,7 @@ def sequence_edges(
         idx_b = torch.arange(1, b.ptr[-1], device=b.ptr.device)
     elif isinstance(b, Data):
         idx_a = torch.arange(0, b.coords.shape[0] - 1, device=b.coords.device)
-        idx_a = torch.arange(1, b.coords.shape[0] - 1, device=b.coords.device)
+        idx_b = torch.arange(1, b.coords.shape[0], device=b.coords.device)
     # Concatenate indices to create edge list
     if direction == "forward":
         e_index = torch.stack([idx_a, idx_b], dim=0)


### PR DESCRIPTION
`proteinworkshop.features.edges.sequence_edges` currently does not work when argument `b` is a PyG `Data` object. This presents a simple fix.