### PR TITLE
Add support for handling training/validation OOMs gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Adds missing `pos` attribute to GearNet `required_batch_attributes` (fixes [#73](https://github.com/a-r-j/ProteinWorkshop/issues/73)) [#74](https://github.com/a-r-j/ProteinWorkshop/pull/74)
 * Fixes PDB download failure due to missing protein data [#77](https://github.com/a-r-j/ProteinWorkshop/pull/77)
+* Add support for handling training/validation OOMs gracefully [#81](https://github.com/a-r-j/ProteinWorkshop/pull/81)
 
 ### Framework
 


### PR DESCRIPTION
* Adds single-GPU support for handling training/validation OOMs gracefully.
* Note that multi-GPU support for OOM-catching (although in principle handled by this code) does not currently work and may lead to unpredictable stalls during training/validation forward (or backward) passes (with the latest release of Lightning - note that this behavior may change with future updates to Lightning).