### PR TITLE
Deprecate torsional denoising task temporarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 ### Features
 * Fix `sequence_edges` behaviour when argument `b` is a `Data` object [#80](https://github.com/a-r-j/ProteinWorkshop/pull/80)
 
+### Tasks
+* Deprecate the `torsional_denoising` task until further runtime testing can be performed [#84](https://github.com/a-r-j/ProteinWorkshop/pull/84)
+
 ### Misc
 * Update ICLR paper link and citation [#82](https://github.com/a-r-j/ProteinWorkshop/pull/82)
 

--- a/proteinworkshop/tasks/torsional_denoising.py
+++ b/proteinworkshop/tasks/torsional_denoising.py
@@ -42,6 +42,9 @@ class TorsionalNoiseTransform(T.BaseTransform):
         :param corruption_rate: Amount to scale noise by, defaults to 0.1
         :type corruption_rate: float, optional
         """
+        raise NotImplementedError(
+            "This transform is not fully implemented yet. Please refer to other transforms for the time being."
+        )
         self.corruption_strategy = corruption_strategy
         self.corruption_rate = corruption_rate
 


### PR DESCRIPTION
* Deprecates the torsional denoising task until further runtime testing can be performed.