### PR TITLE
Add ability for `BenchmarkModel` to have its decoder disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add support for handling training/validation OOMs gracefully [#81](https://github.com/a-r-j/ProteinWorkshop/pull/81)
 * Add support for handling backward OOMs gracefully [#83](https://github.com/a-r-j/ProteinWorkshop/pull/83)
 * Update GCPNet paper link [#85](https://github.com/a-r-j/ProteinWorkshop/pull/85)
+* Add ability for `BenchmarkModel` to have its decoder disabled [#101](https://github.com/a-r-j/ProteinWorkshop/pull/101)
 
 ### Framework
 

--- a/proteinworkshop/models/base.py
+++ b/proteinworkshop/models/base.py
@@ -412,9 +412,13 @@ class BenchMarkModel(BaseModel):
         self.encoder: nn.Module = hydra.utils.instantiate(cfg.encoder)
         logger.info(self.encoder)
 
-        logger.info("Instantiating decoders...")
-        self.decoder: nn.ModuleDict = self._build_output_decoders()
-        logger.info(self.decoder)
+        if hasattr(cfg.decoder, "disable") and cfg.decoder.disable:
+            logger.info("Disabling decoder as requested")
+            self.decoder = None
+        else:
+            logger.info("Instantiating decoders...")
+            self.decoder: nn.ModuleDict = self._build_output_decoders()
+            logger.info(self.decoder)
 
         logger.info("Instantiating losses...")
         self.losses = self.configure_losses(cfg.task.losses)


### PR DESCRIPTION
* Adds the ability for `BenchmarkModel` to have its decoder disabled
* This is useful when loading pretrained model weights that are only used to extract encoder representations
* For example, it's possible to inject this new `decoder.disable` argument as follows:
```python
pretrained_config = OmegaConf.load(
    configs.model.encoder.pretrained.config_path
)
pretrained_config.decoder.disable = True
encoder = BenchMarkModel.load_from_checkpoint(
    configs.model.encoder.pretrained.checkpoint_path,
    strict=False,
    cfg=pretrained_config,
)
```