### PR TITLE
Enable AMP Compatibility for GCP Model to Reduce VRAM Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add support for handling backward OOMs gracefully [#83](https://github.com/a-r-j/ProteinWorkshop/pull/83)
 * Update GCPNet paper link [#85](https://github.com/a-r-j/ProteinWorkshop/pull/85)
 * Add ability for `BenchmarkModel` to have its decoder disabled [#101](https://github.com/a-r-j/ProteinWorkshop/pull/101)
+* Fix dtype mismatch in `gcp.py` that broke Automatic Mixed Precision (AMP) training [#102]
 
 ### Framework
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Add support for handling backward OOMs gracefully [#83](https://github.com/a-r-j/ProteinWorkshop/pull/83)
 * Update GCPNet paper link [#85](https://github.com/a-r-j/ProteinWorkshop/pull/85)
 * Add ability for `BenchmarkModel` to have its decoder disabled [#101](https://github.com/a-r-j/ProteinWorkshop/pull/101)
-* Fix dtype mismatch in `gcp.py` that broke Automatic Mixed Precision (AMP) training [#102]
+* Fix dtype mismatch in `gcp.py` that broke Automatic Mixed Precision (AMP) training [#102](https://github.com/a-r-j/ProteinWorkshop/pull/102)
 
 ### Framework
 


### PR DESCRIPTION
This update allows the GCP model to be used with Automatic Mixed Precision (AMP) training without encountering dtype mismatch errors. Previously, the following error occurred during AMP training:

```command
"proteinworkshop/models/graph_encoders/layers/gcp.py", line 271, in scalarize local_scalar_rep_i[edge_mask] = torch.matmul( RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and Half for the source.</module>
```

Based on my experiments using Huggingface Accelerate AMP (fp16), it reduces VRAM usage by approximately 40% during training.